### PR TITLE
Refactor sensor sampling parameter from `sampling_interval` to `sampling_modulus_time`

### DIFF
--- a/examples/convex_transducer/convex_transducer_abdominal_wall.py
+++ b/examples/convex_transducer/convex_transducer_abdominal_wall.py
@@ -62,7 +62,7 @@ def main() -> None:  # noqa: PLR0915
     # make a sensor for whole domain to make an animation
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=2)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=2)
     sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     #

--- a/examples/linear_transducer/linear_transducer_abdominal_wall.py
+++ b/examples/linear_transducer/linear_transducer_abdominal_wall.py
@@ -125,7 +125,7 @@ def main() -> None:  # noqa: PLR0915
     # make a sensor for whole domain to make an animation
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=2)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=2)
     sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     #

--- a/examples/linear_transducer/linear_transducer_abdominal_wall_with_air.py
+++ b/examples/linear_transducer/linear_transducer_abdominal_wall_with_air.py
@@ -126,7 +126,7 @@ def main() -> None:  # noqa: PLR0915
     # make a sensor for whole domain to make an animation
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=2)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=2)
     sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     #

--- a/examples/linear_transducer/linear_transducer_animation.py
+++ b/examples/linear_transducer/linear_transducer_animation.py
@@ -122,7 +122,7 @@ def main() -> None:
     # make a sensor for whole domain to make an animation
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=2)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=2)
     sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     #

--- a/examples/linear_transducer/linear_transducer_focused_animation.py
+++ b/examples/linear_transducer/linear_transducer_focused_animation.py
@@ -162,7 +162,7 @@ def main() -> None:  # noqa: PLR0915
     # make a sensor for whole domain to make an animation
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=2)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=2)
     sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     #

--- a/examples/medium_builder/medium_builder_abdominal_example.py
+++ b/examples/medium_builder/medium_builder_abdominal_example.py
@@ -126,7 +126,7 @@ def main() -> None:
     # make a sensor for whole domain to make an animation
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=2)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=2)
     sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     # --- run simulation ---

--- a/examples/medium_builder/medium_builder_example.py
+++ b/examples/medium_builder/medium_builder_example.py
@@ -171,7 +171,7 @@ def main() -> None:  # noqa: PLR0915
     # make a sensor for whole domain to make an animation
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=7)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=7)
     sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     # --- run simulation ---

--- a/examples/simple_plane_wave/example_simple_plane_wave.ipynb
+++ b/examples/simple_plane_wave/example_simple_plane_wave.ipynb
@@ -677,7 +677,9 @@
     "Next, we initialize the `Sensor` object with the defined sensor position mask.\n",
     "The `Sensor` class takes the sensor position mask as inputs to create a sensor object that can be used in the wave propagation simulation.\n",
     "\n",
-    "We can also define the sampling interval for the sensor recordings with `sampling_interval` parameter.\n"
+    "We can also define the sampling modulus time for the sensor recordings with `sampling_modulus_time` parameter.\n",
+    "This parameter allows us to control the temporal resolution of the recorded data by specifying how often to record the wavefield during the simulation.\n",
+    "By setting `sampling_modulus_time` to a value greater than 1, we can reduce the size of the output data by recording the wavefield at every nth time step.\n"
    ]
   },
   {
@@ -687,7 +689,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=7)"
+    "sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=7)"
    ]
   },
   {
@@ -1009,7 +1011,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "plotting animation: 100%|██████████| 51/51 [00:00<00:00, 944.48it/s]\n"
+      "plotting animation: 100%|██████████| 51/51 [00:00<00:00, 948.11it/s]\n"
      ]
     },
     {

--- a/examples/simple_plane_wave/simple_plane_wave.py
+++ b/examples/simple_plane_wave/simple_plane_wave.py
@@ -93,7 +93,7 @@ def main() -> None:
     sensor_mask[:, :] = True
 
     # setup the Sensor instance
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=7)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=7)
 
     #
     # --- run simulation ---

--- a/examples/simple_plane_wave/simple_plane_wave_air.py
+++ b/examples/simple_plane_wave/simple_plane_wave_air.py
@@ -91,7 +91,7 @@ def main() -> None:
     # --- define the sensor ---
     sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=7)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=7)
 
     # --- run simulation ---
     fw_solver = fullwave.Solver(

--- a/examples/wave_3d/simple_plane_wave_3d.py
+++ b/examples/wave_3d/simple_plane_wave_3d.py
@@ -107,7 +107,7 @@ def main() -> None:  # noqa: PLR0915
     #
     sensor_mask = np.zeros((grid.nx, grid.ny, grid.nz), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=7)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=7)
 
     #
     # --- run simulation ---

--- a/examples/wave_3d/simple_plane_wave_3d_with_air.py
+++ b/examples/wave_3d/simple_plane_wave_3d_with_air.py
@@ -123,7 +123,7 @@ def main() -> None:  # noqa: PLR0915
     #
     sensor_mask = np.zeros((grid.nx, grid.ny, grid.nz), dtype=bool)
     sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_interval=7)
+    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=7)
 
     #
     # --- run simulation ---

--- a/fullwave/sensor.py
+++ b/fullwave/sensor.py
@@ -19,9 +19,9 @@ class Sensor:
     """Sensor class for Fullwave."""
 
     outcoords: NDArray[np.int64]
-    sampling_interval: int = 1
+    sampling_modulus_time: int = 1
 
-    def __init__(self, mask: NDArray[np.bool], sampling_interval: int = 1) -> None:
+    def __init__(self, mask: NDArray[np.bool], sampling_modulus_time: int = 1) -> None:
         """Sensor class for Fullwave.
 
         Parameters
@@ -29,14 +29,16 @@ class Sensor:
         mask : NDArray[np.bool]
             Binary matrix where the pressure is recorded at each time-step
             shape: [nx, ny] for 2D, [nx, ny, nz] for 3D
-        sampling_interval: int
-            The time-step interval at which the pressure is recorded
+        sampling_modulus_time: int
+            Sampling modulus in time. Default is 1 (record at every time step).
+            Changing this value to n will record the pressure every n time steps.
+            It reduces the size of the output data.
 
         """
         mask = np.atleast_2d(mask)
 
         self.grid_shape = mask.shape
-        self.sampling_interval = sampling_interval
+        self.sampling_modulus_time = sampling_modulus_time
         self.is_3d = len(self.grid_shape) == 3
         outcoords = map_to_coords(mask)
         if self.is_3d:

--- a/fullwave/solver/input_file_writer.py
+++ b/fullwave/solver/input_file_writer.py
@@ -783,7 +783,7 @@ class InputFileWriter:
             ("ncoordsout", self.sensor.n_sensors),
             ("ncoordszero", self.medium.n_air),
             ("nTic", nt_ic),
-            ("modT", self.sensor.sampling_interval),
+            ("modT", self.sensor.sampling_modulus_time),
         ]
         if self.is_3d:
             var_list.extend(

--- a/fullwave/solver/pml_builder.py
+++ b/fullwave/solver/pml_builder.py
@@ -243,7 +243,7 @@ class PMLBuilder:
         )
         self.extended_sensor = fullwave.Sensor(
             mask=self._extend_map_for_pml(self.sensor_org.mask, fill_edge=False),
-            sampling_interval=self.sensor_org.sampling_interval,
+            sampling_modulus_time=self.sensor_org.sampling_modulus_time,
         )
         if self.is_3d:
             self.pml_mask_x, self.pml_mask_y, self.pml_mask_z = self._localize_pml_region()
@@ -1767,7 +1767,7 @@ class PMLBuilderExponentialAttenuation(PMLBuilder):
         )
         self.extended_sensor = fullwave.Sensor(
             mask=self._extend_map_for_pml(self.sensor_org.mask, fill_edge=False),
-            sampling_interval=self.sensor_org.sampling_interval,
+            sampling_modulus_time=self.sensor_org.sampling_modulus_time,
         )
         if self.is_3d:
             self.pml_mask_x, self.pml_mask_y, self.pml_mask_z = self._localize_pml_region()

--- a/fullwave/solver/solver.py
+++ b/fullwave/solver/solver.py
@@ -580,7 +580,7 @@ class Solver:
         is_static_map: bool = False,
         recalculate_pml: bool = True,
         record_whole_domain: bool = False,
-        sampling_interval_whole_domain: int = 1,
+        sampling_modulus_time_whole_domain: int = 1,
         load_results: bool = True,
     ) -> NDArray[np.float64] | Path:
         r"""Run the fullwave simulation and return the result as a NumPy array.
@@ -621,12 +621,13 @@ class Solver:
         record_whole_domain : bool
             Flag indicating whether to record the whole domain.
             If True, the simulation will record data for the entire grid.
-        sampling_interval_whole_domain : int
-            The sampling interval for the sensor data.
-            Default is 1, which means every time step is recorded.
-            If set to a value greater than 1, only every nth time step is recorded.
+        sampling_modulus_time_whole_domain : int
+            Sampling modulus in time. Default is 1 (record at every time step).
+            Changing this value to n will record the pressure every n time steps.
+            It reduces the size of the output data.
             This will only change the sensor class if record_whole_domain is True.
-            If record_whole_domain is False, the sampling interval is ignored.
+            If record_whole_domain is False,
+            the sampling sampling_modulus_time_whole_domain is ignored.
         load_results : bool
             Whether to load the results from genout.dat after the simulation.
             Default is True. If set to False, it returns the genout.dat file path instead.
@@ -640,11 +641,12 @@ class Solver:
 
         # pml setup
         extended_medium = self.pml_builder.run(use_pml=self.use_pml)
-        if sampling_interval_whole_domain != 1 and record_whole_domain is False:
+        if sampling_modulus_time_whole_domain != 1 and record_whole_domain is False:
             warning_msg = (
-                f"sampling_interval_whole_domain value {sampling_interval_whole_domain} is ignored "
+                f"sampling_modulus_time_whole_domain value "
+                f"{sampling_modulus_time_whole_domain} is ignored "
                 "when record_whole_domain is False. "
-                f"The sampling_interval {self.sensor.sampling_interval} "
+                f"The sampling_modulus_time {self.sensor.sampling_modulus_time} "
                 "in the sensor object is prioritized."
             )
             logger.warning(warning_msg)
@@ -668,7 +670,7 @@ class Solver:
             sensor_mask[:, :] = True
             sensor = fullwave.Sensor(
                 mask=sensor_mask,
-                sampling_interval=sampling_interval_whole_domain,
+                sampling_modulus_time=sampling_modulus_time_whole_domain,
             )
         else:
             sensor = self.pml_builder.extended_sensor

--- a/fullwave/transducer.py
+++ b/fullwave/transducer.py
@@ -605,7 +605,7 @@ class Transducer:
         active_sensor_elements: tuple[bool] | None = None,
         *,
         validate_input: bool = True,
-        sampling_interval: int = 1,
+        sampling_modulus_time: int = 1,
     ) -> None:
         """Initialize the GeneralTransducer with the provided geometry, grid, and input signal.
 
@@ -626,8 +626,10 @@ class Transducer:
         validate_input: bool, optional
             Flag indicating whether to validate the input data.
             default is True.
-        sampling_interval: int
-            The time-step interval at which the pressure is recorded
+        sampling_modulus_time: int
+            Sampling modulus in time. Default is 1 (record at every time step).
+            Changing this value to n will record the pressure every n time steps.
+            It reduces the size of the output data.
 
         """
         if validate_input:
@@ -646,7 +648,7 @@ class Transducer:
             active_sensor_elements = np.ones(transducer_geometry.number_elements, dtype=bool)
         self.active_sensor_elements = active_sensor_elements
 
-        self.sampling_interval = sampling_interval
+        self.sampling_modulus_time = sampling_modulus_time
 
         if input_signal is not None:
             self._check_signal(input_signal)
@@ -740,7 +742,7 @@ class Transducer:
         """
         return fullwave.sensor.Sensor(
             self.sensor_mask,
-            sampling_interval=self.sampling_interval,
+            sampling_modulus_time=self.sampling_modulus_time,
         )
 
     @property

--- a/tests/solver/test_input_file_writer.py
+++ b/tests/solver/test_input_file_writer.py
@@ -38,7 +38,7 @@ def create_dummy_objects():
     )
     sensor = SimpleNamespace(
         outcoords=np.array([[1, 2], [3, 4]], dtype=np.int64),
-        sampling_interval=0.5,
+        sampling_modulus_time=0.5,
         n_sensors=2,
     )
     return grid, medium, source, sensor


### PR DESCRIPTION
- Updated the `Sensor` class to use `sampling_modulus_time` instead of `sampling_interval` for defining the time-step interval at which pressure is recorded.
- Modified all instances in example scripts and notebooks to reflect this change, ensuring consistency across the codebase.
- Adjusted relevant documentation and comments to clarify the purpose of the new parameter.