### PR TITLE
Develop

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,46 @@
+[tool.bumpversion]
+current_version = "1.0.16"
+parse = """(?x)
+    (?P<major>0|[1-9]\\d*)\\.
+    (?P<minor>0|[1-9]\\d*)\\.
+    (?P<patch>0|[1-9]\\d*)
+    (?:
+        -                             # dash separator for pre-release section
+        (?P<pre_l>[a-zA-Z-]+)         # pre-release label
+        (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
+    )?                                # pre-release section is optional
+"""
+serialize = [
+    "{major}.{minor}.{patch}-{pre_l}{pre_n}",
+    "{major}.{minor}.{patch}",
+]
+
+commit = true
+message = "Bump version: {current_version} → {new_version}"
+allow_dirty = true
+commit_args = "--no-verify"
+
+tag = true
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+
+pre_commit_hooks = [
+    "uv lock",
+    "git add uv.lock .bumpversion.toml fullwave/__init__.py pyproject.toml",
+]
+
+[[tool.bumpversion.files]]
+# Where the version is stored
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+# Update version in __init__.py
+filename = "fullwave/__init__.py"
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'
+
+[tool.bumpversion.parts.pre_l]
+values = ["dev", "rc", "final"]
+optional_value = "final"

--- a/fullwave/__init__.py
+++ b/fullwave/__init__.py
@@ -1,9 +1,9 @@
 """fullwave module."""
 
-import importlib.metadata
 import logging
 import platform
 import time
+from importlib.metadata import PackageNotFoundError, version
 
 from . import utils
 from .grid import Grid
@@ -56,24 +56,11 @@ if PLATFORM != "linux":
         message,
     )
 
-# Versioning only after package is fully installed
-
-__version__ = "unknown"
-
 try:
-    # First, try getting version from installed package metadata
-    __version__ = importlib.metadata.version(__package__ or __name__)
-except importlib.metadata.PackageNotFoundError:
-    # Fallback: read from pyproject.toml for local development
-    try:
-        import tomllib  # Python 3.11+
-    except ModuleNotFoundError:
-        import tomli as tomllib  # For Python < 3.11, requires install tomli
+    __version__ = version("fullwave")
+except PackageNotFoundError:
+    # Update via bump-my-version, not manually
+    __version__ = "1.0.16"
 
-    from pathlib import Path
-
-    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
-    if pyproject_path.exists():
-        with Path(pyproject_path).open("rb") as f:
-            pyproject_data = tomllib.load(f)
-            __version__ = pyproject_data["project"]["version"]
+VERSION = __version__  # for convenience
+logger.info("Fullwave version: %s", __version__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fullwave25"
-version = "1.0.15"
+version = "1.0.16" # Update via bump-my-version, not manually
 description = "Fullwave 2.5: Ultrasound wave propagation simulation with heterogeneous power law attenuation modelling capabilities"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -658,7 +658,7 @@ wheels = [
 
 [[package]]
 name = "fullwave25"
-version = "1.0.15"
+version = "1.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
#57: Use bump-my-version instead of UV for version management.

improved the quick fix in #55.
This PR resolves the issue of displaying "unknown" versions.