### PR TITLE
update full synthetic aperture example with beamforming using mach.

### DIFF
--- a/examples/linear_transducer/full_synthetic_aperture.py
+++ b/examples/linear_transducer/full_synthetic_aperture.py
@@ -3,12 +3,36 @@
 import logging
 from pathlib import Path
 
+import cupy
 import numpy as np
+import pymust
+from einops import rearrange
+from mach import experimental, wavefront
+from mach.io.must import (
+    linear_probe_positions,
+    scan_grid,
+)
 from tqdm import tqdm
 
 import fullwave
-from fullwave import MediumBuilder, presets
-from fullwave.utils import plot_utils, signal_process
+from fullwave.utils import plot_utils
+
+
+def convert_to_db(signal: np.ndarray) -> np.ndarray:
+    """Convert signal to decibel scale.
+
+    Parameters
+    ----------
+    signal : np.ndarray
+        Input signal array.
+
+    Returns
+    -------
+    np.ndarray
+        Signal in decibel scale.
+
+    """
+    return 20 * np.log10(np.abs(signal) / np.max(np.abs(signal)))
 
 
 def make_input_signal(
@@ -17,6 +41,7 @@ def make_input_signal(
     transducer_geometry: fullwave.TransducerGeometry,
     transducer: fullwave.Transducer,
     element_layer_px: int,
+    *,
     p_max: float = 1e5,
 ) -> np.ndarray:
     """Generate an input signal for single element transmission.
@@ -76,8 +101,119 @@ def make_input_signal(
     return input_signal
 
 
-def main() -> None:
-    """Run linear transducer abdominal wall example."""
+def make_echoic_targets(
+    scatterer: np.ndarray,
+    grid: fullwave.Grid,
+    target_radius_m: float,
+    target_spacing_m: float,
+    start_offset_x_m: float,
+    start_offset_y_m: float,
+    n_targets_axial: int,
+    n_targets_lateral: int,
+    *,
+    centered: bool = True,
+) -> np.ndarray:
+    """Place echoic circles in the scatter map.
+
+    Parameters
+    ----------
+    scatterer : np.ndarray
+        Scatterer map to modify.
+    grid : fullwave.Grid
+        Computational grid.
+    target_radius_m : float
+        Radius of each target in meters.
+    target_spacing_m : float
+        Spacing between targets in meters.
+    start_offset_x_m : float
+        Starting offset in the axial direction in meters.
+    start_offset_y_m : float
+        Starting offset in the lateral direction in meters.
+    n_targets_axial : int
+        Number of targets in the axial direction.
+    n_targets_lateral : int
+        Number of targets in the lateral direction.
+    centered : bool, optional
+        Whether to center the targets in the grid (default: True).
+
+    Returns
+    -------
+    np.ndarray
+        Modified scatterer map with echoic targets.
+
+    """
+    # place echoic circles in the scatter map
+    # each circle has a target_radius_m and is spaced by target_spacing_m
+    if centered:
+        total_axial_length = (n_targets_axial - 1) * target_spacing_m
+        total_lateral_length = (n_targets_lateral - 1) * target_spacing_m
+        start_offset_x_m = (grid.shape[0] * grid.dx - total_axial_length) / 2
+        start_offset_y_m = (grid.shape[1] * grid.dx - total_lateral_length) / 2
+
+    axial_positions = np.linspace(
+        start_offset_x_m,
+        start_offset_x_m + (n_targets_axial - 1) * target_spacing_m,
+        n_targets_axial,
+        endpoint=True,
+    )
+    lateral_positions = np.linspace(
+        start_offset_y_m,
+        start_offset_y_m + (n_targets_lateral - 1) * target_spacing_m,
+        n_targets_lateral,
+        endpoint=True,
+    )
+
+    echoic_target_max = 4
+    echoic_target_min = 2
+
+    hypo_echoic_target_max = 0.6
+    hypo_echoic_target_min = 0.4
+
+    anechoic_target_max = 0.0
+    anechoic_target_min = 0.0
+    hyper_echoic_ratio_array = np.linspace(
+        echoic_target_max,
+        echoic_target_min,
+        n_targets_axial,
+    )
+    hypo_echoic_ratio_array = np.linspace(
+        hypo_echoic_target_max,
+        hypo_echoic_target_min,
+        n_targets_axial,
+    )
+    anechoic_ratio_array = np.linspace(
+        anechoic_target_max,
+        anechoic_target_min,
+        n_targets_axial,
+    )
+    echoic_ratio_array = np.zeros((n_targets_axial, n_targets_lateral))
+    for i in range(n_targets_axial):
+        echoic_ratio_array[i, 0] = anechoic_ratio_array[i]
+        echoic_ratio_array[i, 1] = hypo_echoic_ratio_array[i]
+        echoic_ratio_array[i, 2] = hyper_echoic_ratio_array[i]
+
+    for i_axial, axial_pos in enumerate(axial_positions):
+        for i_lateral, lateral_pos in enumerate(lateral_positions):
+            axial_idx = int(axial_pos / grid.dx)
+            lateral_idx = int(lateral_pos / grid.dx)
+            (
+                rr,
+                cc,
+            ) = np.ogrid[
+                -axial_idx : scatterer.shape[0] - axial_idx,
+                -lateral_idx : scatterer.shape[1] - lateral_idx,
+            ]
+            circle_mask = rr**2 + cc**2 <= (target_radius_m / grid.dx) ** 2
+
+            scatterer -= 1.0
+            scatterer[circle_mask] *= echoic_ratio_array[i_axial, i_lateral]
+            scatterer += 1.0
+
+    return scatterer
+
+
+def main() -> None:  # noqa: PLR0915
+    """Run linear trransducer full synthetic aperture simulation and beamforming."""
     # overwrite the logging level, DEBUG, INFO, WARNING, ERROR
     logging.getLogger("__main__").setLevel(logging.INFO)
 
@@ -92,34 +228,20 @@ def main() -> None:
     #
 
     domain_size = (6e-2, 6e-2)  # [axial, lateral] meters
-    f0 = 1e6
+    f0 = 2e6
     c0 = 1540
-    duration = domain_size[0] / c0 * 1.2
+    duration = domain_size[0] / c0 * 2.3
     grid = fullwave.Grid(domain_size, f0, duration, c0=c0)
-
-    #
-    # --- define the linear transducer ---
-    #
-    # make a sensor for whole domain to make an animation
-    sensor_mask = np.zeros((grid.nx, grid.ny), dtype=bool)
-    sensor_mask[:, :] = True
-    sensor = fullwave.Sensor(mask=sensor_mask, sampling_modulus_time=2)
-    sensor.plot(export_path=work_dir / "sensor_whole.svg")
 
     #
     # --- define the acoustic medium properties ---
     #
-
-    # define background
-    background_property_name = "liver"
-    background = presets.BackgroundDomain(
-        grid=grid,
-        background_property_name=background_property_name,
-    )
-    # define abdominal wall
-    abdominal_wall = presets.AbdominalWallDomain(
-        grid=grid,
-    )
+    sound_speed_map = np.ones(grid.shape) * c0
+    density_map = np.ones(grid.shape) * 1000
+    alpha_coeff_map = np.ones(grid.shape) * 0.5  # dB/(MHz^y cm)
+    alpha_power_map = np.ones(grid.shape) * 1.1  # y
+    beta_map = np.ones(grid.shape) * 0  # nonlinearity parameter
+    air_map = np.zeros(grid.shape)  # no air bubbles
 
     # define scatterer
 
@@ -132,52 +254,71 @@ def main() -> None:
         rng=rng,
     )
 
-    background.density *= scatterer
-    abdominal_wall.density *= scatterer
-
-    # register the domains to MediumBuilder
-    mb = MediumBuilder(
+    scatterer = make_echoic_targets(
+        scatterer=scatterer,
         grid=grid,
+        target_radius_m=5e-3,
+        target_spacing_m=15e-3,
+        start_offset_x_m=10e-3,
+        start_offset_y_m=10e-3,
+        n_targets_axial=3,
+        n_targets_lateral=3,
+        centered=True,
     )
-    mb.register_domain(background)
-    mb.register_domain(abdominal_wall)
+    plot_utils.plot_array(scatterer)
+    # scatterer modulates the density map.
+    # scatterer values are centered around 1.0 with small variations.
+    density_map *= scatterer
 
-    # we can plot to see the current registered domains
-    mb.plot_current_map(export_path=work_dir / "medium.svg")
-
-    # generate medium for simulation
-    medium = mb.run()
-
+    medium = fullwave.Medium(
+        grid,
+        sound_speed=sound_speed_map,
+        density=density_map,
+        alpha_coeff=alpha_coeff_map,
+        alpha_power=alpha_power_map,
+        beta=beta_map,
+        air_map=air_map,
+    )
+    medium.plot(export_path=work_dir / "medium.svg")
     #
-    # --- run simulation ---
+    # --- define the linear transducer ---
     #
 
     active_source_element_id_list = list(range(128))
-    active_source_element_id_list = active_source_element_id_list[::16]  # for faster demo
+    active_source_element_id_list = active_source_element_id_list[32::32]  # for faster demo
 
-    element_layer_px = 1
+    element_layer_px = 4
+    transducer_width_m = 38e-3
     transducer_geometry = fullwave.TransducerGeometry(
         grid,
         number_elements=128,
         # -
-        element_width_m=0.146484375e-3,
+        element_width_m=0.298e-3 - 0.048e-3,
         # -
-        element_spacing_m=0.146484375e-3,
+        element_spacing_m=0.048e-3,
         # -
         element_layer_px=element_layer_px,
         # -
         # [axial, lateral]
         position_m=(
             0,
-            (60 - 37.4) / 2 * 1e-3,
+            (domain_size[1] - transducer_width_m) / 2,
         ),
         # -
         radius=float("inf"),
     )
+
+    sampling_interval = 7
     transducer = fullwave.Transducer(
         transducer_geometry=transducer_geometry,
         grid=grid,
+        sampling_modulus_time=sampling_interval,
     )
+
+    #
+    # --- run simulation ---
+    #
+
     p_max = 1e5
 
     sensor_output_list = []
@@ -191,6 +332,7 @@ def main() -> None:
             transducer_geometry=transducer_geometry,
             transducer=transducer,
             element_layer_px=element_layer_px,
+            p_max=p_max,
         )
         transducer.set_signal(input_signal)
         fw_solver = fullwave.Solver(
@@ -198,7 +340,6 @@ def main() -> None:
             grid=grid,
             medium=medium,
             transducer=transducer,
-            sensor=sensor,
             run_on_memory=False,
         )
         if i_active_source_element_id == 0:
@@ -206,62 +347,120 @@ def main() -> None:
                 is_static_map=True,
                 recalculate_pml=True,
             )
-            sensor_output_list.append(sensor_output)
         else:
             sensor_output = fw_solver.run(
                 simulation_dir_name=f"txrx_{i_active_source_element_id}",
                 is_static_map=True,
                 recalculate_pml=False,  # Reuse PML from first run
             )
-            sensor_output_list.append(sensor_output)
+        sensor_output = fw_solver.transducer.post_process_sensor_output(
+            sensor_output,
+            average_surface_signals=True,
+        )
+        sensor_output_list.append(sensor_output)
+
+    #
+    # --- beamform with mach ---
+    #
+
+    # -- define the beamforming parameters --
+
+    transducer_width_m = transducer.transducer_geometry.transducer_width_m
+
+    params = {
+        "fs": 1 / grid.dt / sampling_interval,  # Sampling frequency (Hz)
+        "fc": f0,  # Center frequency (Hz)
+        "Nelements": 128,  # Number of array elements
+        "pitch": transducer_width_m / 128,  # Element pitch (meters)
+        "c": c0,  # Speed of sound in medium (m/s)
+        # "fnumber": 1.0,
+        "fnumber": 2.0,
+        "t0": 0,  # Start time of data acquisition (seconds)
+    }
+
+    element_positions = linear_probe_positions(params["Nelements"], params["pitch"])
+    b_mode_x = np.linspace(-transducer_width_m / 2, transducer_width_m / 2, num=256, endpoint=True)
+    b_mode_y = np.array([0.0])  # 2D imaging (single y-plane)
+    b_mode_z = np.linspace(5e-3, domain_size[0], num=512, endpoint=True)
+
+    # make grid points for beamforming
+    grid_points = scan_grid(b_mode_x, b_mode_y, b_mode_z)
+
+    # -- compute transmit wavefront arrival times --
+    wavefront_arrivals_s = [
+        wavefront.spherical(
+            origin_m=element_positions[i_elem],
+            points_m=grid_points,
+            focus_m=element_positions[i_elem],  # FSA: focus at each element position
+        )
+        / params["c"]
+        for i_elem in active_source_element_id_list
+    ]
+    for i in range(len(wavefront_arrivals_s)):
+        wavefront_arrivals_s[i] -= wavefront_arrivals_s[i].min()
+    wavefront_arrivals_s = np.stack(wavefront_arrivals_s, axis=0)
+
+    # --- post-process and beamform ---
+
+    sensor_output = np.stack(sensor_output_list, axis=0)
+    sensor_output = sensor_output.transpose(2, 1, 0)
+
+    # Convert RF data to IQ data
+    iq_data = pymust.rf2iq(sensor_output, Fs=params["fs"], Fc=params["fc"])
+
+    # Convert the IQ data to flattened grid points for beamforming
+    iq_data = iq_data[:, :, :, np.newaxis]
+    iq_data = np.ascontiguousarray(
+        rearrange(
+            iq_data,
+            "samples elements transmit frames -> transmit elements samples frames",
+        ),
+        # iq_data,
+        dtype=np.complex64,
+    )
+
+    # run beamforming on GPU.
+    b_mode = experimental.beamform(
+        channel_data=cupy.asarray(iq_data),  # IQ data from all elements
+        rx_coords_m=cupy.asarray(element_positions),  # Array element positions
+        scan_coords_m=cupy.asarray(grid_points),  # Imaging grid coordinates
+        tx_wave_arrivals_s=cupy.asarray(
+            wavefront_arrivals_s,
+        ),  # Transmit arrival times (s)
+        f_number=float(params["fnumber"]),  # Dynamic focusing f-number
+        rx_start_s=float(params["t0"]),  # Data acquisition start time
+        sampling_freq_hz=float(params["fs"]),  # Sampling frequency
+        sound_speed_m_s=float(params["c"]),  # Medium sound speed
+        modulation_freq_hz=float(params["fc"]),  # Demodulation frequency
+        tukey_alpha=0.5,  # No additional windowing
+    )
+
+    # convert cupy to numpy
+    b_mode = cupy.asnumpy(b_mode)
+    # reshape to 2D image
+    b_mode = b_mode.reshape(len(b_mode_x), len(b_mode_z))
 
     #
     # --- visualization ---
     #
-    for sensor_output, active_source_element_id in zip(
-        sensor_output_list,
-        active_source_element_id_list,
-        strict=False,
-    ):
-        propagation_map = signal_process.reshape_whole_sensor_to_nt_nx_ny(
-            sensor_output,
-            grid,
-        )
-        propagation_map = np.nan_to_num(propagation_map, 0, posinf=p_max, neginf=-p_max)
 
-        p_max_plot = np.abs(propagation_map).max().item() / 4
-
-        time_step = propagation_map.shape[0] // 50 * 37
-        plot_utils.plot_wave_propagation_snapshot(
-            propagation_map=propagation_map[time_step],
-            c_map=medium.sound_speed,
-            rho_map=medium.density,
-            export_name=work_dir
-            / f"wave_propagation_snapshot_1_active_element={active_source_element_id:04d}.svg",
-            vmin=-p_max_plot,
-            vmax=p_max_plot,
-            turn_off_axes=True,
-            figsize=(6, 6),
-        )
-
-        plot_utils.plot_wave_propagation_with_map(
-            propagation_map=propagation_map,
-            c_map=medium.sound_speed,
-            rho_map=medium.density,
-            export_name=work_dir
-            / f"wave_propagation_active_element={active_source_element_id:04d}.mp4",
-            vmin=-p_max_plot,
-            vmax=p_max_plot,
-            figsize=(6, 6),
-        )
-
-        # maximum intensity projection
-        plot_utils.plot_array(
-            np.max(np.abs(propagation_map**2), axis=0),
-            aspect=propagation_map.shape[2] / propagation_map.shape[1],
-            export_path=work_dir
-            / f"wave_propagation_mip_active_element={active_source_element_id:04d}.png",
-        )
+    plot_utils.plot_array(
+        convert_to_db(b_mode).T,
+        vmin=-30,
+        vmax=0,
+        aspect=1,
+        cmap="gray",
+        extent=[
+            b_mode_x[0] * 1e3,
+            b_mode_x[-1] * 1e3,
+            b_mode_z[-1] * 1e3,
+            b_mode_z[0] * 1e3,
+        ],
+        xlabel="Lateral position (mm)",
+        ylabel="Axial position (mm)",
+        colorbar=True,
+        export_path=work_dir / "beamformed_image.svg",
+    )
 
 
 if __name__ == "__main__":

--- a/fullwave/transducer.py
+++ b/fullwave/transducer.py
@@ -785,6 +785,10 @@ class Transducer:
             )
             * self.sensor_mask
         )
+        if indexed_element_surface.sum() == 0:
+            indexed_element_surface = (
+                self.transducer_geometry.indexed_element_mask_output * self.sensor_mask
+            )
 
         for i in range(1, self.transducer_geometry.number_elements + 1):
             indexed_element_mask_list = np.stack(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,13 @@ classifiers = [
 [project.optional-dependencies] # --extra
 test = ["pytest", "tomli>=2.3.0"]
 dev = ["pre-commit==4.1.0", "pytest>=8.3.5", "ruff>=0.12.9"]
-examples = ["jupyter>=1.0.0", "ipykernel>=6.28.0"]
+examples = [
+    "jupyter>=1.0.0",
+    "ipykernel>=6.28.0",
+    "mach-beamform>=0.0.4",
+    "cupy-cuda12x>=13.6.0",
+    "pymust>=0.1.8",
+]
 
 [tool.hatch.version]
 path = "fullwave/__init__.py"

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,15 @@ wheels = [
 ]
 
 [[package]]
+name = "array-api-compat"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/36/f799b36d7025a92a23819f9f06541babdb84b6fd0bd4253f8be2eca348a4/array_api_compat-1.13.0.tar.gz", hash = "sha256:8b83a56aa8b9477472fee37f7731968dd213e20c198a05ac49caeff9b03f48a6", size = 103065, upload-time = "2025-12-28T11:26:57.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/5d/493b1b5528ab5072feae30821ff3a07b7a0474213d548efb1fdf135f85c1/array_api_compat-1.13.0-py3-none-any.whl", hash = "sha256:c15026a0ddec42815383f07da285472e1b1ff2e632eb7afbcfe9b08fcbad9bf1", size = 58585, upload-time = "2025-12-28T11:26:56.081Z" },
+]
+
+[[package]]
 name = "arrow"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -457,6 +466,29 @@ wheels = [
 ]
 
 [[package]]
+name = "cupy-cuda12x"
+version = "13.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastrlock" },
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/2e/db22c5148884e4e384f6ebbc7971fa3710f3ba67ca492798890a0fdebc45/cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:9e37f60f27ff9625dfdccc4688a09852707ec613e32ea9404f425dd22a386d14", size = 126341714, upload-time = "2025-08-18T08:24:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/53/2b/8064d94a6ab6b5c4e643d8535ab6af6cabe5455765540931f0ef60a0bc3b/cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e78409ea72f5ac7d6b6f3d33d99426a94005254fa57e10617f430f9fd7c3a0a1", size = 112238589, upload-time = "2025-08-18T08:24:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7b/bac3ca73e164d2b51c6298620261637c7286e06d373f597b036fc45f5563/cupy_cuda12x-13.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f33c9c975782ef7a42c79b6b4fb3d5b043498f9b947126d792592372b432d393", size = 89874119, upload-time = "2025-08-18T08:24:20.628Z" },
+    { url = "https://files.pythonhosted.org/packages/54/64/71c6e08f76c06639e5112f69ee3bc1129be00054ad5f906d7fd3138af579/cupy_cuda12x-13.6.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:c790d012fd4d86872b9c89af9f5f15d91c30b8e3a4aa4dd04c2610f45f06ac44", size = 128016458, upload-time = "2025-08-18T08:24:26.394Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d9/5c5077243cd92368c3eccecdbf91d76db15db338169042ffd1647533c6b1/cupy_cuda12x-13.6.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:77ba6745a130d880c962e687e4e146ebbb9014f290b0a80dbc4e4634eb5c3b48", size = 113039337, upload-time = "2025-08-18T08:24:31.814Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f5/02bea5cdf108e2a66f98e7d107b4c9a6709e5dbfedf663340e5c11719d83/cupy_cuda12x-13.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:a20b7acdc583643a623c8d8e3efbe0db616fbcf5916e9c99eedf73859b6133af", size = 89885526, upload-time = "2025-08-18T08:24:37.258Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/7e7fc4816d0de0154e5d9053242c3a08a0ca8b43ee656a6f7b3b95055a7b/cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:a6970ceefe40f9acbede41d7fe17416bd277b1bd2093adcde457b23b578c5a59", size = 127334633, upload-time = "2025-08-18T08:24:43.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/95/d7e1295141e7d530674a3cc567e13ed0eb6b81524cb122d797ed996b5bea/cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:79b0cacb5e8b190ef409f9e03f06ac8de1b021b0c0dda47674d446f5557e0eb1", size = 112886268, upload-time = "2025-08-18T08:24:49.294Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/14555b63fd78cfac7b88af0094cea0a3cb845d243661ec7da69f7b3ea0de/cupy_cuda12x-13.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca06fede7b8b83ca9ad80062544ef2e5bb8d4762d1c4fc3ac8349376de9c8a5e", size = 89785108, upload-time = "2025-08-18T08:24:54.527Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ec/f62cb991f11fb41291c4c15b6936d7b67ffa71ddb344ad6e8894e06ce58d/cupy_cuda12x-13.6.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e5426ae3b1b9cf59927481e457a89e3f0b50a35b114a8034ec9110e7a833434c", size = 126904601, upload-time = "2025-08-18T08:24:59.951Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/b8/30127bcdac53a25f94ee201bf4802fcd8d012145567d77c54174d6d01c01/cupy_cuda12x-13.6.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:52d9e7f83d920da7d81ec2e791c2c2c747fdaa1d7b811971b34865ce6371e98a", size = 112654824, upload-time = "2025-08-18T08:25:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/72/36/c9e24acb19f039f814faea880b3704a3661edaa6739456b73b27540663e3/cupy_cuda12x-13.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:297b4268f839de67ef7865c2202d3f5a0fb8d20bd43360bc51b6e60cb4406447", size = 89750580, upload-time = "2025-08-18T08:25:10.972Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -552,6 +584,15 @@ wheels = [
 ]
 
 [[package]]
+name = "einops"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/81/df4fbe24dff8ba3934af99044188e20a98ed441ad17a274539b74e82e126/einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84", size = 54805, upload-time = "2025-02-09T03:17:00.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737", size = 64359, upload-time = "2025-02-09T03:17:01.998Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -579,6 +620,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "fastrlock"
+version = "0.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/b1/1c3d635d955f2b4bf34d45abf8f35492e04dbd7804e94ce65d9f928ef3ec/fastrlock-0.8.3.tar.gz", hash = "sha256:4af6734d92eaa3ab4373e6c9a1dd0d5ad1304e172b1521733c6c3b3d73c8fa5d", size = 79327, upload-time = "2024-12-17T11:03:39.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/02/3f771177380d8690812d5b2b7736dc6b6c8cd1c317e4572e65f823eede08/fastrlock-0.8.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:cc5fa9166e05409f64a804d5b6d01af670979cdb12cd2594f555cb33cdc155bd", size = 55094, upload-time = "2024-12-17T11:01:49.721Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/aae7ed94b8122c325d89eb91336084596cebc505dc629b795fcc9629606d/fastrlock-0.8.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:7a77ebb0a24535ef4f167da2c5ee35d9be1e96ae192137e9dc3ff75b8dfc08a5", size = 48220, upload-time = "2024-12-17T11:01:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/96/87/9807af47617fdd65c68b0fcd1e714542c1d4d3a1f1381f591f1aa7383a53/fastrlock-0.8.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:d51f7fb0db8dab341b7f03a39a3031678cf4a98b18533b176c533c122bfce47d", size = 49551, upload-time = "2024-12-17T11:01:52.316Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/12/e201634810ac9aee59f93e3953cb39f98157d17c3fc9d44900f1209054e9/fastrlock-0.8.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:767ec79b7f6ed9b9a00eb9ff62f2a51f56fdb221c5092ab2dadec34a9ccbfc6e", size = 49398, upload-time = "2024-12-17T11:01:53.514Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a1/439962ed439ff6f00b7dce14927e7830e02618f26f4653424220a646cd1c/fastrlock-0.8.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d6a77b3f396f7d41094ef09606f65ae57feeb713f4285e8e417f4021617ca62", size = 53334, upload-time = "2024-12-17T11:01:55.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9e/1ae90829dd40559ab104e97ebe74217d9da794c4bb43016da8367ca7a596/fastrlock-0.8.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:92577ff82ef4a94c5667d6d2841f017820932bc59f31ffd83e4a2c56c1738f90", size = 52495, upload-time = "2024-12-17T11:01:57.76Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/5e746ee6f3d7afbfbb0d794c16c71bfd5259a4e3fb1dda48baf31e46956c/fastrlock-0.8.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3df8514086e16bb7c66169156a8066dc152f3be892c7817e85bf09a27fa2ada2", size = 51972, upload-time = "2024-12-17T11:02:01.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a7/8b91068f00400931da950f143fa0f9018bd447f8ed4e34bed3fe65ed55d2/fastrlock-0.8.3-cp310-cp310-win_amd64.whl", hash = "sha256:001fd86bcac78c79658bac496e8a17472d64d558cd2227fdc768aa77f877fe40", size = 30946, upload-time = "2024-12-17T11:02:03.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/9e/647951c579ef74b6541493d5ca786d21a0b2d330c9514ba2c39f0b0b0046/fastrlock-0.8.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:f68c551cf8a34b6460a3a0eba44bd7897ebfc820854e19970c52a76bf064a59f", size = 55233, upload-time = "2024-12-17T11:02:04.795Z" },
+    { url = "https://files.pythonhosted.org/packages/be/91/5f3afba7d14b8b7d60ac651375f50fff9220d6ccc3bef233d2bd74b73ec7/fastrlock-0.8.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:55d42f6286b9d867370af4c27bc70d04ce2d342fe450c4a4fcce14440514e695", size = 48911, upload-time = "2024-12-17T11:02:06.173Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7a/e37bd72d7d70a8a551b3b4610d028bd73ff5d6253201d5d3cf6296468bee/fastrlock-0.8.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:bbc3bf96dcbd68392366c477f78c9d5c47e5d9290cb115feea19f20a43ef6d05", size = 50357, upload-time = "2024-12-17T11:02:07.418Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ef/a13b8bab8266840bf38831d7bf5970518c02603d00a548a678763322d5bf/fastrlock-0.8.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:77ab8a98417a1f467dafcd2226718f7ca0cf18d4b64732f838b8c2b3e4b55cb5", size = 50222, upload-time = "2024-12-17T11:02:08.745Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e2/5e5515562b2e9a56d84659377176aef7345da2c3c22909a1897fe27e14dd/fastrlock-0.8.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04bb5eef8f460d13b8c0084ea5a9d3aab2c0573991c880c0a34a56bb14951d30", size = 54553, upload-time = "2024-12-17T11:02:10.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8f/65907405a8cdb2fc8beaf7d09a9a07bb58deff478ff391ca95be4f130b70/fastrlock-0.8.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8c9d459ce344c21ff03268212a1845aa37feab634d242131bc16c2a2355d5f65", size = 53362, upload-time = "2024-12-17T11:02:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b9/ae6511e52738ba4e3a6adb7c6a20158573fbc98aab448992ece25abb0b07/fastrlock-0.8.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:33e6fa4af4f3af3e9c747ec72d1eadc0b7ba2035456c2afb51c24d9e8a56f8fd", size = 52836, upload-time = "2024-12-17T11:02:13.74Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3e/c26f8192c93e8e43b426787cec04bb46ac36e72b1033b7fe5a9267155fdf/fastrlock-0.8.3-cp311-cp311-win_amd64.whl", hash = "sha256:5e5f1665d8e70f4c5b4a67f2db202f354abc80a321ce5a26ac1493f055e3ae2c", size = 31046, upload-time = "2024-12-17T11:02:15.033Z" },
+    { url = "https://files.pythonhosted.org/packages/00/df/56270f2e10c1428855c990e7a7e5baafa9e1262b8e789200bd1d047eb501/fastrlock-0.8.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8cb2cf04352ea8575d496f31b3b88c42c7976e8e58cdd7d1550dfba80ca039da", size = 55727, upload-time = "2024-12-17T11:02:17.26Z" },
+    { url = "https://files.pythonhosted.org/packages/57/21/ea1511b0ef0d5457efca3bf1823effb9c5cad4fc9dca86ce08e4d65330ce/fastrlock-0.8.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85a49a1f1e020097d087e1963e42cea6f307897d5ebe2cb6daf4af47ffdd3eed", size = 52201, upload-time = "2024-12-17T11:02:19.512Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/cdecb7aa976f34328372f1c4efd6c9dc1b039b3cc8d3f38787d640009a25/fastrlock-0.8.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f13ec08f1adb1aa916c384b05ecb7dbebb8df9ea81abd045f60941c6283a670", size = 53924, upload-time = "2024-12-17T11:02:20.85Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6d/59c497f8db9a125066dd3a7442fab6aecbe90d6fec344c54645eaf311666/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0ea4e53a04980d646def0f5e4b5e8bd8c7884288464acab0b37ca0c65c482bfe", size = 52140, upload-time = "2024-12-17T11:02:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/62/04/9138943c2ee803d62a48a3c17b69de2f6fa27677a6896c300369e839a550/fastrlock-0.8.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38340f6635bd4ee2a4fb02a3a725759fe921f2ca846cb9ca44531ba739cc17b4", size = 53261, upload-time = "2024-12-17T11:02:24.418Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4b/db35a52589764c7745a613b6943bbd018f128d42177ab92ee7dde88444f6/fastrlock-0.8.3-cp312-cp312-win_amd64.whl", hash = "sha256:da06d43e1625e2ffddd303edcd6d2cd068e1c486f5fd0102b3f079c44eb13e2c", size = 31235, upload-time = "2024-12-17T11:02:25.708Z" },
+    { url = "https://files.pythonhosted.org/packages/92/74/7b13d836c3f221cff69d6f418f46c2a30c4b1fe09a8ce7db02eecb593185/fastrlock-0.8.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5264088185ca8e6bc83181dff521eee94d078c269c7d557cc8d9ed5952b7be45", size = 54157, upload-time = "2024-12-17T11:02:29.196Z" },
+    { url = "https://files.pythonhosted.org/packages/06/77/f06a907f9a07d26d0cca24a4385944cfe70d549a2c9f1c3e3217332f4f12/fastrlock-0.8.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a98ba46b3e14927550c4baa36b752d0d2f7387b8534864a8767f83cce75c160", size = 50954, upload-time = "2024-12-17T11:02:32.12Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4e/94480fb3fd93991dd6f4e658b77698edc343f57caa2870d77b38c89c2e3b/fastrlock-0.8.3-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dbdea6deeccea1917c6017d353987231c4e46c93d5338ca3e66d6cd88fbce259", size = 52535, upload-time = "2024-12-17T11:02:33.402Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a7/ee82bb55b6c0ca30286dac1e19ee9417a17d2d1de3b13bb0f20cefb86086/fastrlock-0.8.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c6e5bfecbc0d72ff07e43fed81671747914d6794e0926700677ed26d894d4f4f", size = 50942, upload-time = "2024-12-17T11:02:34.688Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1d/d4b7782ef59e57dd9dde69468cc245adafc3674281905e42fa98aac30a79/fastrlock-0.8.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2a83d558470c520ed21462d304e77a12639859b205759221c8144dd2896b958a", size = 52044, upload-time = "2024-12-17T11:02:36.613Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a3/2ad0a0a69662fd4cf556ab8074f0de978ee9b56bff6ddb4e656df4aa9e8e/fastrlock-0.8.3-cp313-cp313-win_amd64.whl", hash = "sha256:8d1d6a28291b4ace2a66bd7b49a9ed9c762467617febdd9ab356b867ed901af8", size = 30472, upload-time = "2024-12-17T11:02:37.983Z" },
 ]
 
 [[package]]
@@ -676,8 +753,11 @@ dev = [
     { name = "ruff" },
 ]
 examples = [
+    { name = "cupy-cuda12x" },
     { name = "ipykernel" },
     { name = "jupyter" },
+    { name = "mach-beamform" },
+    { name = "pymust" },
 ]
 test = [
     { name = "pytest" },
@@ -694,12 +774,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cupy-cuda12x", marker = "extra == 'examples'", specifier = ">=13.6.0" },
     { name = "ipykernel", marker = "extra == 'examples'", specifier = ">=6.28.0" },
     { name = "jupyter", marker = "extra == 'examples'", specifier = ">=1.0.0" },
+    { name = "mach-beamform", marker = "extra == 'examples'", specifier = ">=0.0.4" },
     { name = "matplotlib", specifier = ">=3.10.7" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "opencv-python-headless", specifier = ">=4.12.0.88" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.1.0" },
+    { name = "pymust", marker = "extra == 'examples'", specifier = ">=0.1.8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.9" },
@@ -905,6 +988,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/30/0e29eab664d33127a7a30aebd7a845a95fbfa1887ede692676769820acea/jaxtyping-0.3.5.tar.gz", hash = "sha256:8150ad5b72b62fa63f573d492a79e9e455f070abe3b260f7dc15270b3eb9bba6", size = 45482, upload-time = "2026-01-05T10:51:34.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/19/a29de61c7ada0edf4eacfc19355ab8560091b65ea5d2450bcb984e203259/jaxtyping-0.3.5-py3-none-any.whl", hash = "sha256:862c39fa2e526274e82dc96ee8dbe9369dadb651ab1e05d95bd685acb4e2ef02", size = 55824, upload-time = "2026-01-05T10:51:33.523Z" },
 ]
 
 [[package]]
@@ -1305,6 +1400,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "mach-beamform"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "array-api-compat" },
+    { name = "einops" },
+    { name = "jaxtyping" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/2f/abe37187fe88e0fda2b48bf1becaa6d19f620fd91c1f593b669a406fc58e/mach_beamform-0.1.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:449c01f68c2827e0f20dc393cf308e74a78a939b446abb0d1103d6ece462979a", size = 462422, upload-time = "2025-12-09T07:12:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/2946f0126da1bea98d8998684b64f4c7ca1dfcffbc2be9c7d9c0e97b48e6/mach_beamform-0.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:31eab2f66cadcf7207662c479050f6426670e95fc6f143fe4436ed884ef9dc6a", size = 462775, upload-time = "2025-12-09T07:12:06.734Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/2de512bb0ba79219a6469966f91b3b56d2ab2fcf85e2828522c5d14c1cba/mach_beamform-0.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9c9720673228eb3ab0b9bf9a87cbd6f6b2df8a0f88d617fe2123b6aa03897731", size = 461562, upload-time = "2025-12-09T07:12:08.014Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/75/01c2b9dca8b467ac6aa7a2b62d9178597460f5353fab73d5d908feadb311/mach_beamform-0.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f85ca2ede2ac0210f5aa05f6271305d3503f1de7b5008d2c6725c2d1bc8a8991", size = 461491, upload-time = "2025-12-09T07:12:09.006Z" },
 ]
 
 [[package]]
@@ -1906,6 +2017,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pymust"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/b1/0f34022f2d864503f64c5c8a8872c0d3e876962a0a3b963991c20d84e4ee/pymust-0.1.8.tar.gz", hash = "sha256:3ea134f445a70573bfcd48228d817ab73307e668c7eb3d4996a36e249f22bb08", size = 13517715, upload-time = "2025-01-24T14:56:47.992Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/b1/283dd4d11567c545d6c8e79fc07beb54974bf6fa0567838673ab3488fb19/PyMUST-0.1.8-py3-none-any.whl", hash = "sha256:ae0b36eafa595695a5aae3b043b5c3b40584ea7fe50462e571f96f8ed41310c9", size = 125122, upload-time = "2025-01-24T14:56:44.259Z" },
 ]
 
 [[package]]
@@ -2582,6 +2707,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
+]
+
+[[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- update full synthetic aperture example with beamforming using mach.
- Added a check for indexed_element_surface in the Transducer class to ensure proper handling when the sum is zero.
- Updated `pyproject.toml` to include new optional dependencies: mach-beamform, cupy-cuda12x, and pymust for example usage.